### PR TITLE
feat: Task 5 - DetailActivityのメモ機能統合完了

### DIFF
--- a/app/src/androidTest/java/com/example/clothstock/ui/detail/DetailActivityEspressoTest.kt
+++ b/app/src/androidTest/java/com/example/clothstock/ui/detail/DetailActivityEspressoTest.kt
@@ -5,6 +5,8 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.typeText
+import androidx.test.espresso.action.ViewActions.clearText
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -46,7 +48,8 @@ class DetailActivityEspressoTest {
             id = TEST_CLOTH_ITEM_ID,
             imagePath = "/storage/emulated/0/Pictures/test_cloth.jpg",
             tagData = TEST_TAG_DATA,
-            createdAt = Date()
+            createdAt = Date(),
+            memo = "Test memo content"
         )
     }
 
@@ -75,6 +78,10 @@ class DetailActivityEspressoTest {
             onView(withId(R.id.buttonBack))
                 .check(matches(isDisplayed()))
                 .check(matches(isEnabled()))
+            
+            // Task 5: メモ入力ビューの表示確認
+            onView(withId(R.id.memoInputView))
+                .check(matches(isDisplayed()))
         }
     }
 
@@ -270,6 +277,70 @@ class DetailActivityEspressoTest {
             scenario.onActivity { activity ->
                 assert(activity.isFinishing)
             }
+        }
+    }
+
+    // ===== Task 5: メモ機能UIテスト =====
+
+    /**
+     * テスト11: メモ表示機能
+     */
+    @Test
+    fun detailActivity_メモ付きアイテム表示時_メモが正しく表示される() {
+        // Given: メモ付きアイテムのIntent
+        val intent = createDetailIntent(TEST_CLOTH_ITEM_ID)
+        
+        // When: DetailActivityを起動
+        ActivityScenario.launch<DetailActivity>(intent).use {
+            
+            // Then: メモが表示される
+            onView(withId(R.id.memoInputView))
+                .check(matches(isDisplayed()))
+                
+            // メモ入力フィールドに既存のメモが設定される
+            onView(withId(R.id.editTextMemo))
+                .check(matches(isDisplayed()))
+        }
+    }
+
+    /**
+     * テスト12: メモ入力機能
+     */
+    @Test
+    fun detailActivity_メモ入力時_文字数カウンターが更新される() {
+        // Given: DetailActivityが表示されている
+        val intent = createDetailIntent(TEST_CLOTH_ITEM_ID)
+        val testMemo = "新しいメモテストです"
+        
+        // When: メモを入力
+        ActivityScenario.launch<DetailActivity>(intent).use {
+            onView(withId(R.id.editTextMemo))
+                .perform(clearText(), typeText(testMemo))
+            
+            // Then: 文字数カウンターが更新される
+            onView(withId(R.id.textCharacterCount))
+                .check(matches(isDisplayed()))
+                .check(matches(withText(containsString("${testMemo.length}/1000"))))
+        }
+    }
+
+    /**
+     * テスト13: メモ文字数制限機能
+     */
+    @Test
+    fun detailActivity_長文メモ入力時_警告が表示される() {
+        // Given: DetailActivityが表示されている
+        val intent = createDetailIntent(TEST_CLOTH_ITEM_ID)
+        val longMemo = "a".repeat(950) // 警告閾値(900文字)を超える
+        
+        // When: 長文メモを入力
+        ActivityScenario.launch<DetailActivity>(intent).use {
+            onView(withId(R.id.editTextMemo))
+                .perform(clearText(), typeText(longMemo))
+            
+            // Then: 警告アイコンが表示される
+            onView(withId(R.id.iconWarning))
+                .check(matches(isDisplayed()))
         }
     }
 

--- a/app/src/main/res/layout/activity_detail.xml
+++ b/app/src/main/res/layout/activity_detail.xml
@@ -106,6 +106,14 @@
                 android:textColor="@android:color/white"
                 tools:text="2024/01/15 14:30" />
 
+            <!-- Memo input view -->
+            <com.example.clothstock.ui.common.MemoInputView
+                android:id="@+id/memoInputView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:visibility="visible" />
+
         </LinearLayout>
 
         <!-- Back button -->

--- a/app/src/test/java/com/example/clothstock/ui/detail/DetailViewModelTest.kt
+++ b/app/src/test/java/com/example/clothstock/ui/detail/DetailViewModelTest.kt
@@ -1,0 +1,266 @@
+package com.example.clothstock.ui.detail
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.Observer
+import com.example.clothstock.data.model.ClothItem
+import com.example.clothstock.data.model.TagData
+import com.example.clothstock.data.repository.ClothRepository
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.util.Date
+
+/**
+ * DetailViewModelのユニットテスト
+ * 
+ * Task 5実装: メモ機能のテスト
+ * 
+ * TDD Red-Green-Refactorサイクルに基づくテスト実装
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class DetailViewModelTest {
+
+    @get:Rule
+    val instantExecutorRule = InstantTaskExecutorRule()
+
+    @MockK
+    private lateinit var repository: ClothRepository
+
+    private lateinit var viewModel: DetailViewModel
+    private val testDispatcher = StandardTestDispatcher()
+
+    // テスト用データ
+    private val testClothItem = ClothItem(
+        id = 1L,
+        imagePath = "/test/image.jpg",
+        tagData = TagData(
+            size = 100,
+            color = "Blue",
+            category = "トップス"
+        ),
+        createdAt = Date(),
+        memo = "Test memo"
+    )
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+        Dispatchers.setMain(testDispatcher)
+        
+        // デフォルトのリポジトリモック設定
+        coEvery { repository.getItemById(any()) } returns testClothItem
+        coEvery { repository.updateItem(any()) } returns true
+        
+        viewModel = DetailViewModel(repository)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // ===== メモ機能テスト =====
+
+    @Test
+    fun `onMemoChanged should trigger auto save after debounce`() = runTest {
+        // Given
+        val newMemo = "Updated memo"
+        val memoSaveStateObserver: Observer<DetailViewModel.MemoSaveState> = mockk(relaxed = true)
+        viewModel.memoSaveState.observeForever(memoSaveStateObserver)
+        
+        // アイテムをロード
+        viewModel.loadClothItem(1L)
+        advanceTimeBy(100L)
+        
+        // When
+        viewModel.onMemoChanged(newMemo)
+        
+        // debounce時間経過前は保存されない
+        advanceTimeBy(500L)
+        coVerify(exactly = 0) { repository.updateItem(any()) }
+        
+        // debounce時間経過後は保存される
+        advanceTimeBy(1000L)
+        
+        // Then
+        val updatedItemSlot = slot<ClothItem>()
+        coVerify { repository.updateItem(capture(updatedItemSlot)) }
+        assertEquals(newMemo, updatedItemSlot.captured.memo)
+        
+        verify { memoSaveStateObserver.onChanged(DetailViewModel.MemoSaveState.Saving) }
+        verify { memoSaveStateObserver.onChanged(DetailViewModel.MemoSaveState.Saved) }
+    }
+
+    @Test
+    fun `saveMemoImmediately should save without debounce`() = runTest {
+        // Given
+        val newMemo = "Immediate save memo"
+        val memoSaveStateObserver: Observer<DetailViewModel.MemoSaveState> = mockk(relaxed = true)
+        viewModel.memoSaveState.observeForever(memoSaveStateObserver)
+        
+        // アイテムをロード
+        viewModel.loadClothItem(1L)
+        advanceTimeBy(100L)
+        
+        // When
+        viewModel.saveMemoImmediately(newMemo)
+        advanceTimeBy(1L) // 最小時間進行
+        
+        // Then
+        val updatedItemSlot = slot<ClothItem>()
+        coVerify { repository.updateItem(capture(updatedItemSlot)) }
+        assertEquals(newMemo, updatedItemSlot.captured.memo)
+        
+        verify { memoSaveStateObserver.onChanged(DetailViewModel.MemoSaveState.Saving) }
+        verify { memoSaveStateObserver.onChanged(DetailViewModel.MemoSaveState.Saved) }
+    }
+
+    @Test
+    fun `memo save error should be handled properly`() = runTest {
+        // Given
+        val errorMessage = "Database error"
+        coEvery { repository.updateItem(any()) } throws RuntimeException(errorMessage)
+        
+        val memoSaveStateObserver: Observer<DetailViewModel.MemoSaveState> = mockk(relaxed = true)
+        viewModel.memoSaveState.observeForever(memoSaveStateObserver)
+        
+        // アイテムをロード
+        viewModel.loadClothItem(1L)
+        advanceTimeBy(100L)
+        
+        // When
+        viewModel.saveMemoImmediately("Test memo")
+        advanceTimeBy(1L)
+        
+        // Then
+        verify { memoSaveStateObserver.onChanged(DetailViewModel.MemoSaveState.Saving) }
+        verify { 
+            memoSaveStateObserver.onChanged(
+                match<DetailViewModel.MemoSaveState> { 
+                    it is DetailViewModel.MemoSaveState.Error && 
+                    it.message.contains(errorMessage) 
+                }
+            ) 
+        }
+    }
+
+    @Test
+    fun `getCurrentMemo should return current item memo`() = runTest {
+        // Given
+        val testMemo = "Test memo from item"
+        val itemWithMemo = testClothItem.copy(memo = testMemo)
+        
+        // リポジトリのモックを設定
+        coEvery { repository.getItemById(1L) } returns itemWithMemo
+        
+        // When
+        viewModel.loadClothItem(1L)
+        advanceTimeBy(1L) // 非同期処理の完了を待つ
+        
+        // Then
+        assertEquals(testMemo, viewModel.getCurrentMemo())
+    }
+
+    @Test
+    fun `getCurrentMemo should return empty string when no item`() {
+        // Given - アイテムがロードされていない状態
+        
+        // When
+        val result = viewModel.getCurrentMemo()
+        
+        // Then
+        assertEquals("", result)
+    }
+
+    @Test
+    fun `clearMemoSaveState should reset state to Idle`() {
+        // Given
+        val memoSaveStateObserver: Observer<DetailViewModel.MemoSaveState> = mockk(relaxed = true)
+        viewModel.memoSaveState.observeForever(memoSaveStateObserver)
+        
+        // When
+        viewModel.clearMemoSaveState()
+        
+        // Then
+        verify { memoSaveStateObserver.onChanged(DetailViewModel.MemoSaveState.Idle) }
+    }
+
+    @Test
+    fun `memo with over max length should be trimmed`() = runTest {
+        // Given
+        val longMemo = "a".repeat(ClothItem.MAX_MEMO_LENGTH + 100)
+        
+        // アイテムをロード
+        viewModel.loadClothItem(1L)
+        advanceTimeBy(100L)
+        
+        // When
+        viewModel.saveMemoImmediately(longMemo)
+        advanceTimeBy(1L)
+        
+        // Then
+        val updatedItemSlot = slot<ClothItem>()
+        coVerify { repository.updateItem(capture(updatedItemSlot)) }
+        assertEquals(ClothItem.MAX_MEMO_LENGTH, updatedItemSlot.captured.memo.length)
+        assertEquals(longMemo.take(ClothItem.MAX_MEMO_LENGTH), updatedItemSlot.captured.memo)
+    }
+
+    // ===== 既存機能テスト（メモ機能統合確認） =====
+
+    @Test
+    fun `loadClothItem should load item with memo`() = runTest {
+        // Given
+        val itemObserver: Observer<ClothItem?> = mockk(relaxed = true)
+        viewModel.clothItem.observeForever(itemObserver)
+        
+        // When
+        viewModel.loadClothItem(1L)
+        advanceTimeBy(1L)
+        
+        // Then
+        coVerify { repository.getItemById(1L) }
+        verify { itemObserver.onChanged(testClothItem) }
+        assertEquals("Test memo", viewModel.getCurrentMemo())
+    }
+
+    @Test
+    fun `memo update should update clothItem LiveData`() = runTest {
+        // Given
+        val newMemo = "Updated memo content"
+        val itemObserver: Observer<ClothItem?> = mockk(relaxed = true)
+        viewModel.clothItem.observeForever(itemObserver)
+        
+        // アイテムをロード
+        viewModel.loadClothItem(1L)
+        advanceTimeBy(100L)
+        
+        // When
+        viewModel.saveMemoImmediately(newMemo)
+        advanceTimeBy(1L)
+        
+        // Then
+        verify { 
+            itemObserver.onChanged(
+                match<ClothItem> { item -> 
+                    item?.memo == newMemo 
+                }
+            ) 
+        }
+    }
+}


### PR DESCRIPTION
DetailActivityにMemoInputViewを統合し、メモの表示・編集・自動保存機能を実装

## 実装内容

### 1. DetailActivityレイアウト更新
- activity_detail.xmlのlayoutTagInfoにMemoInputViewを追加
- メモ表示エリアの統合とレイアウト調整

### 2. DetailViewModel機能拡張
- メモ保存・更新機能の実装
- debounceによる自動保存機能（1秒遅延）
- MemoSaveState（Idle, Saving, Saved, Error）による状態管理
- リアルタイムメモ変更監視機能

### 3. DetailActivity統合
- MemoInputViewの初期化とイベント処理
- メモ変更時の自動保存機能統合
- 保存完了・エラー時のSnackbar表示
- ViewModelとの双方向データバインディング

### 4. TDDテスト実装
- DetailViewModelTest: メモ機能の包括的なユニットテスト
  - 自動保存（debounce）機能テスト
  - 即座保存機能テスト
  - エラーハンドリングテスト
  - 文字数制限テスト
- DetailActivityEspressoTest: メモ機能のUIテスト
  - メモ表示・入力機能テスト
  - 文字数カウンターテスト
  - 警告表示テスト

### 5. 品質確認
- ユニットテスト: 全テスト通過
- lint: 品質チェック通過
- detekt: 静的解析通過（新規コード関連）
- ビルド: Debug/Release両方成功

🤖 Generated with [Claude Code](https://claude.ai/code)