### PR TITLE
fix: SwipeableDetailPanel 再表示問題を修正

### DIFF
--- a/app/src/main/java/com/example/clothstock/ui/common/SwipeableDetailPanel.kt
+++ b/app/src/main/java/com/example/clothstock/ui/common/SwipeableDetailPanel.kt
@@ -188,6 +188,9 @@ class SwipeableDetailPanel @JvmOverloads constructor(
             val oldState = panelState
             panelState = state
             
+            // 視覚的状態変更を適用
+            applyVisualStateChange(state)
+            
             // パフォーマンス最適化：不要な通知を避ける
             if (notifyListener) {
                 onPanelStateChangedListener?.invoke(state)
@@ -197,6 +200,46 @@ class SwipeableDetailPanel @JvmOverloads constructor(
             // リリースビルドとテスト時はログを無効化、不要な文字列構築を回避
             if (android.util.Log.isLoggable(LOG_TAG, android.util.Log.DEBUG) && !isTestEnvironment()) {
                 android.util.Log.d(LOG_TAG, "Panel state changed: $oldState -> $state")
+            }
+        }
+    }
+    
+    /**
+     * パネル状態変更時の視覚的変更を適用
+     * @param newState 新しい状態
+     */
+    private fun applyVisualStateChange(newState: PanelState) {
+        // アニメーション進行中フラグを設定
+        if (newState == PanelState.ANIMATING) {
+            // アニメーション状態では視覚的変更なし
+            return
+        }
+        
+        // SwipeableDetailPanel自体は常に表示状態を維持
+        visibility = android.view.View.VISIBLE
+        alpha = 1.0f
+        
+        // コンテンツコンテナーの表示制御
+        binding?.contentContainer?.let { contentContainer ->
+            when (newState) {
+                PanelState.SHOWN -> {
+                    // パネル表示状態：コンテンツを表示
+                    contentContainer.visibility = android.view.View.VISIBLE
+                    contentContainer.alpha = 1.0f
+                    if (android.util.Log.isLoggable(LOG_TAG, android.util.Log.DEBUG)) {
+                        android.util.Log.d(LOG_TAG, "パネルコンテンツを表示状態に設定")
+                    }
+                }
+                PanelState.HIDDEN -> {
+                    // パネル非表示状態：コンテンツのみ非表示、ハンドルは表示維持
+                    contentContainer.visibility = android.view.View.GONE
+                    if (android.util.Log.isLoggable(LOG_TAG, android.util.Log.DEBUG)) {
+                        android.util.Log.d(LOG_TAG, "パネルコンテンツを非表示状態に設定（ハンドルは表示維持）")
+                    }
+                }
+                PanelState.ANIMATING -> {
+                    // アニメーション中（上で既に処理済み）
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/clothstock/ui/common/SwipeableDetailPanel.kt
+++ b/app/src/main/java/com/example/clothstock/ui/common/SwipeableDetailPanel.kt
@@ -7,6 +7,7 @@ import android.util.AttributeSet
 import android.view.GestureDetector
 import android.view.LayoutInflater
 import android.view.MotionEvent
+import android.view.View
 import android.view.animation.AccelerateDecelerateInterpolator
 import android.view.animation.DecelerateInterpolator
 import android.view.animation.Interpolator
@@ -216,7 +217,7 @@ class SwipeableDetailPanel @JvmOverloads constructor(
         }
         
         // SwipeableDetailPanel自体は常に表示状態を維持
-        visibility = android.view.View.VISIBLE
+        visibility = View.VISIBLE
         alpha = 1.0f
         
         // コンテンツコンテナーの表示制御
@@ -224,7 +225,7 @@ class SwipeableDetailPanel @JvmOverloads constructor(
             when (newState) {
                 PanelState.SHOWN -> {
                     // パネル表示状態：コンテンツを表示
-                    contentContainer.visibility = android.view.View.VISIBLE
+                    contentContainer.visibility = View.VISIBLE
                     contentContainer.alpha = 1.0f
                     if (android.util.Log.isLoggable(LOG_TAG, android.util.Log.DEBUG)) {
                         android.util.Log.d(LOG_TAG, "パネルコンテンツを表示状態に設定")
@@ -232,7 +233,7 @@ class SwipeableDetailPanel @JvmOverloads constructor(
                 }
                 PanelState.HIDDEN -> {
                     // パネル非表示状態：コンテンツのみ非表示、ハンドルは表示維持
-                    contentContainer.visibility = android.view.View.GONE
+                    contentContainer.visibility = View.GONE
                     if (android.util.Log.isLoggable(LOG_TAG, android.util.Log.DEBUG)) {
                         android.util.Log.d(LOG_TAG, "パネルコンテンツを非表示状態に設定（ハンドルは表示維持）")
                     }

--- a/app/src/main/java/com/example/clothstock/ui/detail/DetailActivity.kt
+++ b/app/src/main/java/com/example/clothstock/ui/detail/DetailActivity.kt
@@ -643,7 +643,9 @@ class DetailActivity : AppCompatActivity() {
      */
     private fun setupSwipeableDetailPanelComponents(panel: SwipeableDetailPanel) {
         try {
-            android.util.Log.d("DetailActivity", "SwipeableDetailPanel内コンポーネント初期化開始")
+            if (BuildConfig.DEBUG) {
+                android.util.Log.d("DetailActivity", "SwipeableDetailPanel内コンポーネント初期化開始")
+            }
             
             // SwipeableDetailPanel内のMemoInputViewを取得
             val panelMemoInputView = panel.findViewById<MemoInputView>(R.id.memoInputView)
@@ -670,7 +672,9 @@ class DetailActivity : AppCompatActivity() {
                 }
             }
             
-            android.util.Log.d("DetailActivity", "SwipeableDetailPanel内コンポーネント初期化完了")
+            if (BuildConfig.DEBUG) {
+                android.util.Log.d("DetailActivity", "SwipeableDetailPanel内コンポーネント初期化完了")
+            }
         } catch (e: Exception) {
             android.util.Log.e("DetailActivity", "SwipeableDetailPanel内コンポーネント初期化失敗", e)
             
@@ -718,7 +722,9 @@ class DetailActivity : AppCompatActivity() {
      * SwipeableDetailPanelまたはフォールバックレイアウトを表示
      */
     private fun showDetailPanel() {
-        android.util.Log.d("DetailActivity", "詳細パネル表示開始 - SwipeableDetailPanel: ${swipeableDetailPanel != null}")
+        if (BuildConfig.DEBUG) {
+            android.util.Log.d("DetailActivity", "詳細パネル表示開始 - SwipeableDetailPanel: ${swipeableDetailPanel != null}")
+        }
         
         try {
             if (swipeableDetailPanel != null) {


### PR DESCRIPTION
詳細:
- 詳細情報クリック後に再表示できない問題を解決
- SwipeableDetailPanel全体ではなくcontentContainerのみ制御
- スワイプハンドルが常に表示され、いつでも再表示可能
- DetailActivity初期化エラーハンドリング強化
- ログ出力レベル調整とデバッグ情報改善

修正内容:
- applyVisualStateChange()メソッド新規実装
- HIDDEN状態でcontentContainerのみGONEに設定
- SwipeableDetailPanel自体は常にVISIBLE維持
- setupSwipeableDetailPanel()エラーハンドリング強化
- ensureFallbackLayoutIsAvailable()メソッド追加

ユーザー体験向上:
- 直感的な操作：スワイプハンドル常時表示
- 視覚的明確さ：パネル状態が分かりやすい
- アクセシビリティ：いつでもアクセス可能

🤖 Generated with [Claude Code](https://claude.ai/code)